### PR TITLE
Created util for linksInNewTab that tests for hrefs starting with https?://

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "jump.js": "^1.0.2",
-    "marked3": "^0.5.1",
+    "marked3": "^0.5.2",
     "prismjs": "^1.8.4",
     "slugo": "^0.2.1",
     "unfetch": "^3.0.0",

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -25,6 +25,7 @@ import slugo from 'slugo'
 import jump from 'jump.js'
 
 import highlight from '../utils/highlight'
+import linksInNewTab from '../utils/links-in-new-tab'
 import DocMenu from './Menu.vue'
 import DocLoading from './Loading.vue'
 
@@ -89,7 +90,7 @@ export default {
       if (SHOW_START.test(html)) {
         return marked(html.replace(SHOW_START, '').replace(/^-->$/m, ''), {
           highlight: this.opts.highlight && highlightFn,
-          linksInNewTab: true
+          linksInNewTab
         })
       }
       return html
@@ -99,7 +100,7 @@ export default {
     let html = marked(content, {
       renderer,
       highlight: this.opts.highlight && highlightFn,
-      linksInNewTab: true
+      linksInNewTab
     })
 
     // Strip out hidden contents

--- a/src/utils/links-in-new-tab.js
+++ b/src/utils/links-in-new-tab.js
@@ -1,4 +1,4 @@
-const RE = /https?:\/\//
+const RE = /^https?:\/\//
 
 export default function linksInNewTab(href) {
   return RE.test(href)

--- a/src/utils/links-in-new-tab.js
+++ b/src/utils/links-in-new-tab.js
@@ -1,0 +1,5 @@
+const RE = /https?:\/\//
+
+export default function linksInNewTab(href) {
+  return RE.test(href)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3641,9 +3641,9 @@ markdown-escapes@^1.0.0:
   version "1.0.1"
   resolved "http://registry.npm.taobao.org/markdown-escapes/download/markdown-escapes-1.0.1.tgz#1994df2d3af4811de59a6714934c2b2292734518"
 
-marked3@^0.5.1:
-  version "0.5.1"
-  resolved "http://registry.npm.taobao.org/marked3/download/marked3-0.5.1.tgz#af006fe7d4f949d42f036c9a403094f7675d0db2"
+marked3@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/marked3/-/marked3-0.5.2.tgz#4570728cc4b58afb253e72aeb2a5acde1fc96f51"
   dependencies:
     slugo "^0.2.1"
 


### PR DESCRIPTION
This PR depends on https://github.com/egoist/marked3/pull/8 getting merged. We'll also want to bump the version number in `package.json` once that happens.