### PR TITLE
Feature: add copy button on code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "egoist <0x142857@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "copy-text-to-clipboard": "^2.2.0",
     "element-in-view": "^0.1.0",
     "htm": "^3.0.4",
     "marked": "^1.0.0",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,7 @@
 import { h, FunctionComponent } from 'preact'
 import { useEffect, useState } from 'preact/hooks'
 import inView from 'element-in-view'
+import copy from 'copy-text-to-clipboard'
 import { InstanceOptions } from '../docup'
 import { Navbar } from './Navbar'
 import { Sidebar } from './Sidebar'
@@ -75,8 +76,13 @@ export const App: FunctionComponent<{ options: InstanceOptions }> = ({
     const handleClick = (e: MouseEvent) => {
       let target = e.target as any
       if (target.closest) {
-        target = target.closest('a')
-        if (!target) {
+        const copyButton = target.closest('.copy_button');
+        if (copyButton) {
+          copy(copyButton.nextSibling.innerText)
+          return;
+        } 
+    
+        if (!target.closest('a')) {
           return
         }
       } else {

--- a/src/css/content.css
+++ b/src/css/content.css
@@ -134,3 +134,44 @@ blockquote p:not(:first-child),
 .task_list__item input[type=checkbox]:first-child {
   @apply mr-2;
 }
+
+.code_block {
+  position: relative;
+}
+
+.code_block:hover .copy_button {
+  opacity: 1;
+  visibility: visible;
+}
+
+.copy_button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 32px;
+  height: 24px;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  color: #ccc;
+  background-color: hsla(0,0%,90.2%, .2);
+  box-shadow: 0 2px 0 0 rgba(0,0,0, .25);
+  outline: none;
+  opacity: 0;
+  visibility: hidden;
+  user-select: none;
+  transition: opacity .2s ease-in-out,visibility .2s ease-in-out;
+}
+.copy_button:focus {
+  outline: none;
+}
+.copy_icon {
+  display: inline-block;
+  line-height: 0;
+  text-align: center;
+}

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -6,7 +6,7 @@ import 'prismjs/components/prism-typescript'
 import 'prismjs/components/prism-json'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-markdown'
-import { isExternalLink, slugify, ANCHOR_ICON } from './utils'
+import { isExternalLink, slugify, ANCHOR_ICON, COPY_ICON } from './utils'
 import htm from 'htm'
 import { render, h } from 'preact'
 import * as hooks from 'preact/hooks'
@@ -60,7 +60,7 @@ export function renderMarkdown(text: string, { props }: { props: any }) {
       })
       return `<div id="code-replacement-${index}"></div>`
     }
-    return originalCode.call(renderer, code, lang, escaped)
+    return `<div class="code_block"><button class="copy_button"><i class="copy_icon">${COPY_ICON}</i></button>${originalCode.call(renderer, code, lang, escaped)}</div>`
   }
 
   renderer.link = (href, title, text) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,9 @@ export function isExternalLink(href: string) {
 export const ANCHOR_ICON = `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-link"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path></svg>
 `
 
+export const COPY_ICON = `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" fill="currentColor" viewBox="64 64 896 896" width="14" height="14"><path d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z" /></svg>
+`
+
 export function scrollToHash(hash: string) {
   const el = document.querySelector(hash) as HTMLDivElement
   if (el) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,6 +2260,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-text-to-clipboard@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npm.taobao.org/copy-text-to-clipboard/download/copy-text-to-clipboard-2.2.0.tgz#329dd6daf8c42034c763ace567418401764579ae"
+  integrity sha1-Mp3W2vjEIDTHY6zlZ0GEAXZFea4=
+
 copy-webpack-plugin@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz#5481a03dea1123d88a988c6ff8b78247214f0b88"


### PR DESCRIPTION
Related to #4   

I can't wait to implement this function first. 🤓

When hover to the code block, a copy button will appear in the upper right corner as the screenshot shown below. 
![image](https://user-images.githubusercontent.com/33575974/83791105-d7f5bf00-a6cb-11ea-8347-752ae3c595e4.png)
