### PR TITLE
feat: create a fre build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .DS_Store
 *.log
+yarn.lock

--- a/docs/README.md
+++ b/docs/README.md
@@ -141,8 +141,6 @@ docup.init({
 Available languages:
 
 ```js preact
-const { useState } = hooks
-
 export default ({ langs }) => {
   const [showAll, setShowAll] = useState(false)
   return html`<div>
@@ -167,8 +165,6 @@ You can inline Preact components inside Markdown file like this:
 
 ````markdown
 ```js preact
-const { useState } = hooks
-
 export default () => {
   const [count, setCount] = useState(0)
   return html`<button
@@ -184,8 +180,6 @@ export default () => {
 Write `preact` next to the language name and we will render the code as a Preact component in place:
 
 ```js preact
-const { useState } = hooks
-
 export default () => {
   const [count, setCount] = useState(0)
   return html`<button
@@ -202,9 +196,6 @@ export default () => {
 ### CSS Variables
 
 ```js preact
-const { useEffect, useState } = hooks
-
-// could pass in an array of specific stylesheets for optimization
 function getAllCSSVariableNames(styleSheets = document.styleSheets) {
   var cssVars = []
   // loop each stylesheet

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -28,7 +28,10 @@ const config: UserConfig = {
   },
   resolve: {
     alias: {
-      renderer: path.resolve('src/renderer/preact.ts'),
+      renderer:
+        process.env.NODE_ENV === 'fre'
+          ? path.resolve('src/renderer/fre.ts')
+          : path.resolve('src/renderer/preact.ts'),
     },
   },
   plugins: [

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -26,6 +26,11 @@ const config: UserConfig = {
     jsxFactory: 'h',
     jsxFragment: 'Fragment',
   },
+  resolve: {
+    alias: {
+      renderer: path.resolve('src/renderer/preact.ts'),
+    },
+  },
   plugins: [
     prefresh(),
     windicss({

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
   },
   "scripts": {
     "test": "echo skip",
-    "build": "NODE_ENV=production rollup -c",
+    "build": "cross-env NODE_ENV=production rollup -c",
     "dev": "vite docs",
+    "dev:fre": "cross-env vite docs NODE_ENV=fre",
     "build:website": "vite build docs && cp docs/README.md docs/dist/",
     "prepublishOnly": "npm run build"
   },
@@ -55,6 +56,7 @@
     "type-fest": "^0.21.2",
     "typescript": "^4.2.3",
     "vite": "^2.1.3",
-    "vite-plugin-windicss": "^0.9.11"
+    "vite-plugin-windicss": "^0.9.11",
+    "cross-env": "7.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@prefresh/vite": "^2.1.0",
+    "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@types/debug": "^4.1.5",
@@ -46,6 +47,7 @@
     "clean-css": "^5.1.0",
     "debug": "^4.3.1",
     "esbuild": "^0.10.0",
+    "fre": "^2.0.4",
     "prettier": "^2.2.1",
     "rollup": "^2.42.4",
     "rollup-plugin-dts": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ devDependencies:
   '@types/marked': 1.2.2
   '@types/prismjs': 1.16.4
   clean-css: 5.1.2
+  cross-env: 7.0.3
   debug: 4.3.1
   esbuild: 0.10.0
   fre: 2.0.4
@@ -486,6 +487,27 @@ packages:
     dev: true
     resolution:
       integrity: sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  /cross-env/7.0.3:
+    dependencies:
+      cross-spawn: 7.0.3
+    dev: true
+    engines:
+      node: '>=10.14'
+      npm: '>=6'
+      yarn: '>=1'
+    hasBin: true
+    resolution:
+      integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  /cross-spawn/7.0.3:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: true
+    engines:
+      node: '>= 8'
+    resolution:
+      integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   /debug/4.3.1:
     dependencies:
       ms: 2.1.2
@@ -714,6 +736,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  /isexe/2.0.0:
+    dev: true
+    resolution:
+      integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
   /joycon/3.0.1:
     dev: true
     engines:
@@ -837,6 +863,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+  /path-key/3.1.1:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
   /path-parse/1.0.6:
     dev: true
     resolution:
@@ -958,6 +990,20 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+  /shebang-command/2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  /shebang-regex/3.0.0:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
   /slash/3.0.0:
     dev: true
     engines:
@@ -1077,6 +1123,15 @@ packages:
       fsevents: 2.3.2
     resolution:
       integrity: sha512-bUzArZIUwADVJS/3ywCr4KKFn3a7izs4M87ZDlAlY2V34E4g1kH6p3sVNAh8/IXCn/56fwgMh3rRavPUW7qEQQ==
+  /which/2.0.2:
+    dependencies:
+      isexe: 2.0.0
+    dev: true
+    engines:
+      node: '>= 8'
+    hasBin: true
+    resolution:
+      integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   /windicss/2.5.5:
     dev: true
     engines:
@@ -1097,6 +1152,7 @@ specifiers:
   '@types/marked': ^1.2.2
   '@types/prismjs': ^1.16.3
   clean-css: ^5.1.0
+  cross-env: 7.0.3
   debug: ^4.3.1
   element-in-view: ^0.1.0
   esbuild: ^0.10.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ dependencies:
   prismjs: 1.23.0
 devDependencies:
   '@prefresh/vite': 2.1.1_c9376b4c3d4a42f913703c014bd70d0e
+  '@rollup/plugin-alias': 3.1.2_rollup@2.42.4
   '@rollup/plugin-commonjs': 17.1.0_rollup@2.42.4
   '@rollup/plugin-node-resolve': 11.2.0_rollup@2.42.4
   '@types/debug': 4.1.5
@@ -14,6 +15,7 @@ devDependencies:
   clean-css: 5.1.2
   debug: 4.3.1
   esbuild: 0.10.0
+  fre: 2.0.4
   prettier: 2.2.1
   rollup: 2.42.4
   rollup-plugin-dts: 3.0.1_rollup@2.42.4+typescript@4.2.3
@@ -260,6 +262,17 @@ packages:
       vite: '>=2.0.0-beta.3'
     resolution:
       integrity: sha512-E/nSPUVJL3GBXSDFZimmS+fafx04Clb1bjqP/ZYNL+fVWTYo+dFMwd8VUUXJrrYzpBVwtq1EUz80u03iRcr12A==
+  /@rollup/plugin-alias/3.1.2_rollup@2.42.4:
+    dependencies:
+      rollup: 2.42.4
+      slash: 3.0.0
+    dev: true
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    resolution:
+      integrity: sha512-wzDnQ6v7CcoRzS0qVwFPrFdYA4Qlr+ookA217Y2Z3DPZE1R8jrFNM3jvGgOf6o6DMjbnQIn5lCIJgHPe1Bt3uw==
   /@rollup/plugin-commonjs/17.1.0_rollup@2.42.4:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.42.4
@@ -577,6 +590,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  /fre/2.0.4:
+    dev: true
+    resolution:
+      integrity: sha512-4PhECDE2LC7WGxKEIeY/1fnQ6mGVGSGwy2IR42WL/w4iq16Z/rGmFuwkBnKEWyLHZEieZg1oqUVUPSDzLbBzSA==
   /fs.realpath/1.0.0:
     dev: true
     resolution:
@@ -941,6 +958,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+  /slash/3.0.0:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
   /source-map/0.5.7:
     dev: true
     engines:
@@ -1067,6 +1090,7 @@ packages:
       integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 specifiers:
   '@prefresh/vite': ^2.1.0
+  '@rollup/plugin-alias': ^3.1.2
   '@rollup/plugin-commonjs': ^17.1.0
   '@rollup/plugin-node-resolve': ^11.2.0
   '@types/debug': ^4.1.5
@@ -1076,6 +1100,7 @@ specifiers:
   debug: ^4.3.1
   element-in-view: ^0.1.0
   esbuild: ^0.10.0
+  fre: ^2.0.4
   htm: ^3.0.4
   marked: ^2.0.0
   preact: ^10.5.12

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,13 +3,19 @@ import dtsPlugin from 'rollup-plugin-dts'
 import esbuildPlugin from 'rollup-plugin-esbuild'
 import nodeResolvePlugin from '@rollup/plugin-node-resolve'
 import commonjsPlugin from '@rollup/plugin-commonjs'
+import aliasPlugin from '@rollup/plugin-alias'
 import windicss from './rollup-plugin-windicss'
 import pkg from './package.json'
 
-const createConfig = ({ minify, format, dts } = {}) => {
-  const filename = `[name]${format === 'esm' ? '.esm' : ''}${
+const createConfig = ({ minify, format, dts, renderer } = {}) => {
+  renderer = renderer || 'preact'
+  const isFre = renderer === 'fre'
+  let filename = `[name]${format === 'esm' ? '.esm' : ''}${
     minify ? '.min' : ''
   }.js`
+  if (isFre) {
+    filename = filename.replace('[name]', '[name].fre')
+  }
   return {
     input: 'src/docup.ts',
     output: {
@@ -24,6 +30,11 @@ const createConfig = ({ minify, format, dts } = {}) => {
         extensions: dts
           ? ['.d.ts', '.ts']
           : ['.js', '.ts', '.json', '.tsx', '.mjs'],
+      }),
+      aliasPlugin({
+        entries: {
+          renderer: path.resolve('src/renderer/' + renderer + '.ts'),
+        },
       }),
       windicss({
         minify,
@@ -54,8 +65,10 @@ export default [
   createConfig({ dts: true }),
   // UMD format
   createConfig({ format: 'umd' }),
+  createConfig({ format: 'umd', renderer: 'fre' }),
   // Minified UMD format
   createConfig({ format: 'umd', minify: true }),
+  createConfig({ format: 'umd', minify: true, renderer: 'fre' }),
   // ESM format
   createConfig({ format: 'esm' }),
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,6 +54,7 @@ const createConfig = ({ minify, format, dts, renderer } = {}) => {
             DOCUP_VERSION: JSON.stringify(pkg.version),
             PRISM_VERSION: JSON.stringify(pkg.dependencies.prismjs),
           },
+          target: ['es2020', 'edge88', 'safari14', 'chrome88'],
         }),
       dts && dtsPlugin(),
     ].filter(Boolean),

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,4 @@
-import { h, FunctionComponent } from 'preact'
-import { useEffect, useState } from 'preact/hooks'
+import { h, FC, useEffect, useState } from 'renderer'
 import inView from 'element-in-view'
 import { InstanceOptions } from '../docup'
 import { Navbar } from './Navbar'
@@ -35,9 +34,7 @@ const handleScroll = throttle(() => {
 
 export type LoadingState = 'loading' | 'success' | 'error'
 
-export const App: FunctionComponent<{ options: InstanceOptions }> = ({
-  options,
-}) => {
+export const App: FC<{ options: InstanceOptions }> = ({ options }) => {
   const navLinks = options.navLinks || []
   const [html, setHtml] = useState('')
   const [loadingState, setLoadingState] = useState<LoadingState>('loading')

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,4 +1,4 @@
-import { h, FC } from 'renderer'
+import { h, FC, setHtml } from 'renderer'
 import { LoadingState } from './App'
 
 export const Main: FC<{
@@ -15,12 +15,7 @@ export const Main: FC<{
             <div class="loader rounded h-4 w-48 mt-3"></div>
           </section>
         ) : (
-          <div
-            className="content"
-            ref={(dom) => {
-              dom && (dom.innerHTML = html)
-            }}
-          ></div>
+          <div className="content" {...setHtml(html)}></div>
         )}
       </div>
     </div>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -8,17 +8,18 @@ export const Main: FC<{
   return (
     <div class="mt-12 main">
       <div class="max-w-2xl xl:max-w-4xl">
-        {loadingState === 'loading' && (
-          <div class="">
+        {loadingState === 'loading' ? (
+          <section class="">
             <div class="loader rounded h-4 w-32"></div>
             <div class="loader rounded h-4 w-64 mt-3"></div>
             <div class="loader rounded h-4 w-48 mt-3"></div>
-          </div>
-        )}
-        {loadingState !== 'loading' && (
+          </section>
+        ) : (
           <div
             className="content"
-            dangerouslySetInnerHTML={{ __html: html }}
+            ref={(dom) => {
+              dom && (dom.innerHTML = html)
+            }}
           ></div>
         )}
       </div>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,7 +1,7 @@
-import { h, FunctionComponent } from 'preact'
+import { h, FC } from 'renderer'
 import { LoadingState } from './App'
 
-export const Main: FunctionComponent<{
+export const Main: FC<{
   html: string
   loadingState: LoadingState
 }> = ({ html, loadingState }) => {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
-import { FunctionComponent, h } from 'preact'
+import { FC, h } from 'renderer'
 import { NavLink } from '../docup'
 
-export const Navbar: FunctionComponent<{
+export const Navbar: FC<{
   navLinks: NavLink[]
   title: string
   base: string

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { h, FC, useEffect, useState, useRef } from 'renderer'
+import { h, FC, useEffect, useState, useRef, setHtml } from 'renderer'
 import { SidebarMenuItem } from '../markdown'
 import { NavLink } from '../docup'
 
@@ -80,9 +80,7 @@ export const Sidebar: FC<{
               key={index}
               data-depth={item.depth}
               href={`#${item.slug}`}
-              ref={(dom)=>{
-                dom && (dom.innerHTML = item.text)
-              }}
+              {...setHtml(item.text)}
             ></a>
           )
         })}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -80,7 +80,9 @@ export const Sidebar: FC<{
               key={index}
               data-depth={item.depth}
               href={`#${item.slug}`}
-              dangerouslySetInnerHTML={{ __html: item.text }}
+              ref={(dom)=>{
+                dom && (dom.innerHTML = item.text)
+              }}
             ></a>
           )
         })}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,8 @@
-import { h, FunctionComponent } from 'preact'
+import { h, FC, useEffect, useState, useRef } from 'renderer'
 import { SidebarMenuItem } from '../markdown'
-import { useEffect, useState, useRef } from 'preact/hooks'
 import { NavLink } from '../docup'
 
-export const Sidebar: FunctionComponent<{
+export const Sidebar: FC<{
   menu: SidebarMenuItem[]
   title: string
   base: string

--- a/src/docup.ts
+++ b/src/docup.ts
@@ -3,7 +3,7 @@ import './css/prism.css'
 import './css/main.css'
 import './css/content.css'
 import { SetRequired } from 'type-fest'
-import { h, render } from 'preact'
+import { h, render } from 'renderer'
 import { App } from './components/App'
 
 export interface NavLink {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -8,8 +8,8 @@ import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-markdown'
 import { isExternalLink, slugify, ANCHOR_ICON } from './utils'
 import htm from 'htm'
-import { render, h } from 'preact'
-import * as hooks from 'preact/hooks'
+import * as renderer from 'renderer'
+import { render, h } from 'renderer'
 
 const BLOCKQUOTE_TAG_RE = /^<p>(?:<strong>)?(Note|Alert|Info|Warning|Success|Alert)(?:<\/strong>)?\:\s*/i
 
@@ -41,14 +41,14 @@ export function renderMarkdown(text: string, { props }: { props: any }) {
 
   renderer.code = (code, _lang = '', escaped) => {
     const [lang, info] = _lang.split(' ')
-    if (info === 'preact') {
+    if (info === 'preact' || info === 'fre') {
       const index = codeReplacementIndex++
       fns.push(() => {
         const newCode = `${code.replace(/export\s+default\s/, 'return ')}`
         const getComponent = new Function('html', 'hooks', newCode)
         let Component
         try {
-          Component = getComponent(htm.bind(h), hooks)
+          Component = getComponent(htm.bind(h), renderer)
         } catch (error) {
           console.error(`Error compiling code block`)
           throw error

--- a/src/renderer/fre.ts
+++ b/src/renderer/fre.ts
@@ -1,0 +1,1 @@
+export * from 'fre'

--- a/src/renderer/fre.ts
+++ b/src/renderer/fre.ts
@@ -1,1 +1,5 @@
 export * from 'fre'
+
+export function setHtml(html: string) {
+  return { ref: (dom: any) => (dom.innerHTML = html) }
+}

--- a/src/renderer/preact.ts
+++ b/src/renderer/preact.ts
@@ -1,0 +1,5 @@
+export { h, render } from 'preact'
+
+export type { FunctionComponent as FC } from 'preact'
+
+export * from 'preact/hooks'

--- a/src/renderer/preact.ts
+++ b/src/renderer/preact.ts
@@ -3,3 +3,7 @@ export { h, render } from 'preact'
 export type { FunctionComponent as FC } from 'preact'
 
 export * from 'preact/hooks'
+
+export function setHtml(html: string) {
+  return { dangerouslySetInnerHTML: { __html: html } }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,15 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2017",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    "lib": ["es2019", "dom"],                             /* Specify library files to be included in the compilation. */
+    "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "lib": [
+      "es2019",
+      "dom"
+    ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "jsx": "preserve" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
     "jsxFactory": "h",
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
@@ -26,7 +29,7 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -43,13 +46,15 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
+    "paths": {
+      "renderer": ["src/renderer/preact"]
+    } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
@@ -64,7 +69,7 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
TODO:

it doesn't work yet since preact uses `dangerouslySetInnerHTML` while fre uses `innerHTML`. /cc @yisar

---

the fre build will be available as `docup/dist/docup.fre.min.js`